### PR TITLE
Downgrade target framework from .NET 9.0 to .NET 8.0

### DIFF
--- a/HumanReadableCalculationSteps.Tests/HumanReadableCalculationSteps.Tests.csproj
+++ b/HumanReadableCalculationSteps.Tests/HumanReadableCalculationSteps.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/HumanReadableCalculationSteps/HumanReadableCalculationSteps.csproj
+++ b/HumanReadableCalculationSteps/HumanReadableCalculationSteps.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/TestDebug/TestDebug.csproj
+++ b/TestDebug/TestDebug.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Updated all three projects to target .NET 8.0 instead of .NET 9.0
- HumanReadableCalculationSteps library: net9.0 → net8.0
- HumanReadableCalculationSteps.Tests: net9.0 → net8.0  
- TestDebug: net9.0 → net8.0

## Test plan
- [x] Verify all projects build successfully with .NET 8.0
- [x] Run existing unit tests to ensure compatibility
- [x] Confirm NuGet package generation works with .NET 8.0