### PR TITLE
feat: Add comparison operators with bool return type and decimal support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Claude Instructions for Human-Readable-Calculation-Steps-Dotnet
+
+## Project Configuration
+
+### .NET Version
+**IMPORTANT**: Keep all project files targeting **.NET 8.0**. Do not upgrade to .NET 9.0 or any other version unless explicitly requested by the user.
+
+- Target Framework: `net8.0`
+- This applies to both:
+  - `/HumanReadableCalculationSteps/HumanReadableCalculationSteps.csproj`
+  - `/HumanReadableCalculationSteps.Tests/HumanReadableCalculationSteps.Tests.csproj`
+
+### Reason
+The project is configured for .NET 8.0 for compatibility and stability reasons. Changing the target framework may cause issues with dependencies, CI/CD pipelines, or deployment environments.
+
+## Project Conventions
+
+1. **Testing**: All new features should have comprehensive unit tests
+2. **Naming**: Follow existing naming conventions in the codebase
+3. **Operators**: When implementing operators, maintain consistency with existing patterns
+4. **Documentation**: Keep code self-documenting with clear method and class names
+
+## Development Guidelines
+
+- Run tests before committing any changes
+- Maintain backward compatibility when adding new features
+- Follow existing code style and formatting

--- a/HumanReadableCalculationSteps.Tests/ComparisonTests.cs
+++ b/HumanReadableCalculationSteps.Tests/ComparisonTests.cs
@@ -1,0 +1,382 @@
+using Xunit;
+
+namespace HumanReadableCalculationSteps.Tests
+{
+    public class ComparisonTests
+    {
+        [Fact]
+        public void GreaterThan_WhenLeftIsGreater_ShouldReturnTrue()
+        {
+            var a = 10m.As("a");
+            var b = 5m.As("b");
+            
+            var result = a > b;
+            
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void GreaterThan_WhenLeftIsSmaller_ShouldReturnFalse()
+        {
+            var a = 5m.As("a");
+            var b = 10m.As("b");
+            
+            var result = a > b;
+            
+            Assert.False(result);
+        }
+        
+        [Fact]
+        public void GreaterThan_WhenEqual_ShouldReturnFalse()
+        {
+            var a = 10m.As("a");
+            var b = 10m.As("b");
+            
+            var result = a > b;
+            
+            Assert.False(result);
+        }
+        
+        [Fact]
+        public void LessThan_WhenLeftIsSmaller_ShouldReturnTrue()
+        {
+            var a = 5m.As("a");
+            var b = 10m.As("b");
+            
+            var result = a < b;
+            
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void LessThan_WhenLeftIsGreater_ShouldReturnFalse()
+        {
+            var a = 10m.As("a");
+            var b = 5m.As("b");
+            
+            var result = a < b;
+            
+            Assert.False(result);
+        }
+        
+        [Fact]
+        public void LessThan_WhenEqual_ShouldReturnFalse()
+        {
+            var a = 10m.As("a");
+            var b = 10m.As("b");
+            
+            var result = a < b;
+            
+            Assert.False(result);
+        }
+        
+        [Fact]
+        public void GreaterThanOrEqual_WhenLeftIsGreater_ShouldReturnTrue()
+        {
+            var a = 10m.As("a");
+            var b = 5m.As("b");
+            
+            var result = a >= b;
+            
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void GreaterThanOrEqual_WhenEqual_ShouldReturnTrue()
+        {
+            var a = 10m.As("a");
+            var b = 10m.As("b");
+            
+            var result = a >= b;
+            
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void GreaterThanOrEqual_WhenLeftIsSmaller_ShouldReturnFalse()
+        {
+            var a = 5m.As("a");
+            var b = 10m.As("b");
+            
+            var result = a >= b;
+            
+            Assert.False(result);
+        }
+        
+        [Fact]
+        public void LessThanOrEqual_WhenLeftIsSmaller_ShouldReturnTrue()
+        {
+            var a = 5m.As("a");
+            var b = 10m.As("b");
+            
+            var result = a <= b;
+            
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void LessThanOrEqual_WhenEqual_ShouldReturnTrue()
+        {
+            var a = 10m.As("a");
+            var b = 10m.As("b");
+            
+            var result = a <= b;
+            
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void LessThanOrEqual_WhenLeftIsGreater_ShouldReturnFalse()
+        {
+            var a = 10m.As("a");
+            var b = 5m.As("b");
+            
+            var result = a <= b;
+            
+            Assert.False(result);
+        }
+        
+        [Fact]
+        public void Equality_WhenEqual_ShouldReturnTrue()
+        {
+            var a = 10m.As("a");
+            var b = 10m.As("b");
+            
+            var result = a == b;
+            
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void Equality_WhenNotEqual_ShouldReturnFalse()
+        {
+            var a = 10m.As("a");
+            var b = 5m.As("b");
+            
+            var result = a == b;
+            
+            Assert.False(result);
+        }
+        
+        [Fact]
+        public void Inequality_WhenNotEqual_ShouldReturnTrue()
+        {
+            var a = 10m.As("a");
+            var b = 5m.As("b");
+            
+            var result = a != b;
+            
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void Inequality_WhenEqual_ShouldReturnFalse()
+        {
+            var a = 10m.As("a");
+            var b = 10m.As("b");
+            
+            var result = a != b;
+            
+            Assert.False(result);
+        }
+        
+        [Fact]
+        public void Comparison_WithComputedValues_ShouldWork()
+        {
+            var a = 10m.As("a");
+            var b = 5m.As("b");
+            var sum = (a + b).As("sum");
+            var product = (a * b).As("product");
+            
+            var result = sum < product;
+            
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void Comparison_WithDecimalValues_ShouldWork()
+        {
+            var a = 10.5m.As("a");
+            var b = 10.25m.As("b");
+            
+            var result = a > b;
+            
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void Comparison_WithNegativeValues_ShouldWork()
+        {
+            var a = (-5m).As("a");
+            var b = (-10m).As("b");
+            
+            var result = a > b;
+            
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void Comparison_WithZero_ShouldWork()
+        {
+            var a = 0m.As("a");
+            var b = 5m.As("b");
+            
+            var result = a < b;
+            
+            Assert.True(result);
+        }
+        
+        // Decimal comparison tests
+        [Fact]
+        public void GreaterThan_ValueWithCaptionVsDecimal_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(a > 5m);
+            Assert.False(a > 15m);
+            Assert.False(a > 10m);
+        }
+        
+        [Fact]
+        public void GreaterThan_DecimalVsValueWithCaption_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(15m > a);
+            Assert.False(5m > a);
+            Assert.False(10m > a);
+        }
+        
+        [Fact]
+        public void LessThan_ValueWithCaptionVsDecimal_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(a < 15m);
+            Assert.False(a < 5m);
+            Assert.False(a < 10m);
+        }
+        
+        [Fact]
+        public void LessThan_DecimalVsValueWithCaption_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(5m < a);
+            Assert.False(15m < a);
+            Assert.False(10m < a);
+        }
+        
+        [Fact]
+        public void GreaterThanOrEqual_ValueWithCaptionVsDecimal_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(a >= 5m);
+            Assert.True(a >= 10m);
+            Assert.False(a >= 15m);
+        }
+        
+        [Fact]
+        public void GreaterThanOrEqual_DecimalVsValueWithCaption_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(15m >= a);
+            Assert.True(10m >= a);
+            Assert.False(5m >= a);
+        }
+        
+        [Fact]
+        public void LessThanOrEqual_ValueWithCaptionVsDecimal_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(a <= 15m);
+            Assert.True(a <= 10m);
+            Assert.False(a <= 5m);
+        }
+        
+        [Fact]
+        public void LessThanOrEqual_DecimalVsValueWithCaption_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(5m <= a);
+            Assert.True(10m <= a);
+            Assert.False(15m <= a);
+        }
+        
+        [Fact]
+        public void Equality_ValueWithCaptionVsDecimal_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(a == 10m);
+            Assert.False(a == 5m);
+            Assert.False(a == 15m);
+        }
+        
+        [Fact]
+        public void Equality_DecimalVsValueWithCaption_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(10m == a);
+            Assert.False(5m == a);
+            Assert.False(15m == a);
+        }
+        
+        [Fact]
+        public void Inequality_ValueWithCaptionVsDecimal_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(a != 5m);
+            Assert.True(a != 15m);
+            Assert.False(a != 10m);
+        }
+        
+        [Fact]
+        public void Inequality_DecimalVsValueWithCaption_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            Assert.True(5m != a);
+            Assert.True(15m != a);
+            Assert.False(10m != a);
+        }
+        
+        [Fact]
+        public void Comparison_WithIntegers_ShouldWork()
+        {
+            var a = 10m.As("a");
+            
+            // Integer comparisons should work via implicit conversion to decimal
+            Assert.True(a > 5);
+            Assert.True(a < 15);
+            Assert.True(a >= 10);
+            Assert.True(a <= 10);
+            Assert.True(a == 10);
+            Assert.True(a != 5);
+            
+            Assert.True(15 > a);
+            Assert.True(5 < a);
+            Assert.True(10 >= a);
+            Assert.True(10 <= a);
+            Assert.True(10 == a);
+            Assert.True(5 != a);
+        }
+        
+        [Fact]
+        public void Comparison_DecimalWithNegativeValues_ShouldWork()
+        {
+            var a = (-5m).As("a");
+            
+            Assert.True(a > -10m);
+            Assert.True(a < 0m);
+            Assert.True(a == -5m);
+            Assert.True(a != -10m);
+        }
+    }
+}

--- a/HumanReadableCalculationSteps/StaticValues.cs
+++ b/HumanReadableCalculationSteps/StaticValues.cs
@@ -1,0 +1,9 @@
+﻿// namespace HumanReadableCalculationSteps;
+
+using HumanReadableCalculationSteps;
+
+public static class StaticValues
+{
+    public static readonly ValueWithCaption Zero = 0.As("0");
+    public static readonly ValueWithCaption One = 0.As("1");
+}

--- a/HumanReadableCalculationSteps/ValueWithCaption.cs
+++ b/HumanReadableCalculationSteps/ValueWithCaption.cs
@@ -275,6 +275,119 @@ public class ValueWithCaption(decimal value, string caption, int precedence = 0,
         var steps = CombineCalculationSteps(left, right);
         return new ValueWithCaption(result, $"{leftStr} ÷ {rightStr}", precedence, steps);
     }
+
+    // Greater than
+    public static bool operator >(ValueWithCaption left, ValueWithCaption right)
+    {
+        return left.Value > right.Value;
+    }
+
+    // Less than
+    public static bool operator <(ValueWithCaption left, ValueWithCaption right)
+    {
+        return left.Value < right.Value;
+    }
+
+    // Greater than or equal
+    public static bool operator >=(ValueWithCaption left, ValueWithCaption right)
+    {
+        return left.Value >= right.Value;
+    }
+
+    // Less than or equal
+    public static bool operator <=(ValueWithCaption left, ValueWithCaption right)
+    {
+        return left.Value <= right.Value;
+    }
+
+    // Equality
+    public static bool operator ==(ValueWithCaption left, ValueWithCaption right)
+    {
+        return left.Value == right.Value;
+    }
+
+    // Inequality
+    public static bool operator !=(ValueWithCaption left, ValueWithCaption right)
+    {
+        return left.Value != right.Value;
+    }
+
+    // Decimal comparison overloads - Greater than
+    public static bool operator >(ValueWithCaption left, decimal right)
+    {
+        return left.Value > right;
+    }
+
+    public static bool operator >(decimal left, ValueWithCaption right)
+    {
+        return left > right.Value;
+    }
+
+    // Decimal comparison overloads - Less than
+    public static bool operator <(ValueWithCaption left, decimal right)
+    {
+        return left.Value < right;
+    }
+
+    public static bool operator <(decimal left, ValueWithCaption right)
+    {
+        return left < right.Value;
+    }
+
+    // Decimal comparison overloads - Greater than or equal
+    public static bool operator >=(ValueWithCaption left, decimal right)
+    {
+        return left.Value >= right;
+    }
+
+    public static bool operator >=(decimal left, ValueWithCaption right)
+    {
+        return left >= right.Value;
+    }
+
+    // Decimal comparison overloads - Less than or equal
+    public static bool operator <=(ValueWithCaption left, decimal right)
+    {
+        return left.Value <= right;
+    }
+
+    public static bool operator <=(decimal left, ValueWithCaption right)
+    {
+        return left <= right.Value;
+    }
+
+    // Decimal comparison overloads - Equality
+    public static bool operator ==(ValueWithCaption left, decimal right)
+    {
+        return left.Value == right;
+    }
+
+    public static bool operator ==(decimal left, ValueWithCaption right)
+    {
+        return left == right.Value;
+    }
+
+    // Decimal comparison overloads - Inequality
+    public static bool operator !=(ValueWithCaption left, decimal right)
+    {
+        return left.Value != right;
+    }
+
+    public static bool operator !=(decimal left, ValueWithCaption right)
+    {
+        return left != right.Value;
+    }
+
+    // Override Equals and GetHashCode since we're overriding == and !=
+    public override bool Equals(object? obj)
+    {
+        return obj is ValueWithCaption other && Value == other.Value && Caption == other.Caption;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Value, Caption);
+    }
 }
 
 public class NamedValueWithCaption(decimal value, string caption, int precedence = -1, List<string>? calculationSteps = null)


### PR DESCRIPTION
## Summary
Implements comparison operators that return boolean values and support direct decimal comparisons, as discussed in #16.

## Changes
- ✅ Implement all comparison operators (`>`, `<`, `>=`, `<=`, `==`, `\!=`) that return `bool`
- ✅ Add overloads for direct decimal comparisons (ValueWithCaption vs decimal and vice versa)
- ✅ Add comprehensive test suite with 34 tests covering all scenarios
- ✅ Support integer comparisons via implicit decimal conversion
- ✅ Add CLAUDE.md with project conventions

## Implementation Details
- **Total operators**: 18 (6 comparison types × 3 variations each)
- **No implicit conversions**: Direct decimal comparisons only
- **Integer support**: Works via C#'s built-in int-to-decimal conversion

## Example Usage
```csharp
var a = 10m.As("a");

// ValueWithCaption comparisons
if (a > 5m.As("b")) { /* true */ }

// Direct decimal comparisons
if (a > 5.5m) { /* true */ }
if (15m > a) { /* true */ }

// Integer comparisons (auto-converted)
if (a == 10) { /* true */ }
if (5 < a) { /* true */ }
```

## Test Results
All 117 tests passing, including 34 new comparison tests.

Closes #16