### PR TITLE
feat: Add dual publishing to NuGet.org and GitHub Packages

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -63,6 +63,11 @@ jobs:
     - name: Publish to NuGet
       run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
+    - name: Publish to GitHub Packages
+      run: |
+        dotnet nuget add source --username AppifySheets --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/AppifySheets/index.json"
+        dotnet nuget push ./artifacts/*.nupkg --source "github" --skip-duplicate
+
     - name: Create GitHub Release
       if: startsWith(github.ref, 'refs/tags/') && github.event_name != 'release'
       uses: actions/create-release@v1


### PR DESCRIPTION
## Summary
Add GitHub Packages publishing alongside NuGet.org to make packages visible in GitHub's 'Packages' section.

## Changes
- ✅ Add GitHub Packages publishing step to workflow
- ✅ Configure GitHub Packages source with authentication
- ✅ Maintain existing NuGet.org publishing
- ✅ Use GITHUB_TOKEN for GitHub Packages authentication

## Benefits
- Package will appear in GitHub's 'Packages' section
- Better discoverability for users
- Dual publishing for multiple installation options

## Installation Methods
Users can now install from either:
1. NuGet.org (recommended): `dotnet add package Appify.HumanReadableCalculationSteps`
2. GitHub Packages: Configure source and install from GitHub

This enables the GitHub 'Packages' section to show published packages instead of 'No packages published'.