### PR TITLE
Fix: Only run CI/CD pipeline on main branch tags

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -23,12 +23,35 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Check if tag is on main branch
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      run: |
+        TAG_NAME=${GITHUB_REF#refs/tags/}
+        echo "Checking if tag $TAG_NAME exists on main branch..."
+        
+        # Check if the tag commit is reachable from main
+        if ! git merge-base --is-ancestor $TAG_NAME origin/main; then
+          echo "❌ Tag $TAG_NAME is not on main branch. Skipping release."
+          echo "SKIP_RELEASE=true" >> $GITHUB_ENV
+        else
+          echo "✅ Tag $TAG_NAME is on main branch. Proceeding with release."
+          echo "SKIP_RELEASE=false" >> $GITHUB_ENV
+        fi
+
+    - name: Skip if not on main branch
+      if: env.SKIP_RELEASE == 'true'
+      run: |
+        echo "This tag is not on the main branch. Releases are only published from main branch tags."
+        exit 0
+
     - name: Setup .NET
+      if: env.SKIP_RELEASE != 'true'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
 
     - name: Determine version
+      if: env.SKIP_RELEASE != 'true'
       id: version
       run: |
         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -43,33 +66,40 @@ jobs:
         echo "Publishing version: $VERSION"
 
     - name: Update project version
+      if: env.SKIP_RELEASE != 'true'
       run: |
         sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.version.outputs.VERSION }}<\/Version>/" HumanReadableCalculationSteps/HumanReadableCalculationSteps.csproj
         sed -i "s/<AssemblyVersion>.*<\/AssemblyVersion>/<AssemblyVersion>${{ steps.version.outputs.VERSION }}<\/AssemblyVersion>/" HumanReadableCalculationSteps/HumanReadableCalculationSteps.csproj
         sed -i "s/<FileVersion>.*<\/FileVersion>/<FileVersion>${{ steps.version.outputs.VERSION }}<\/FileVersion>/" HumanReadableCalculationSteps/HumanReadableCalculationSteps.csproj
 
     - name: Restore dependencies
+      if: env.SKIP_RELEASE != 'true'
       run: dotnet restore
 
     - name: Build
+      if: env.SKIP_RELEASE != 'true'
       run: dotnet build --configuration Release --no-restore
 
     - name: Test
+      if: env.SKIP_RELEASE != 'true'
       run: dotnet test --configuration Release --no-build --verbosity normal
 
     - name: Pack
+      if: env.SKIP_RELEASE != 'true'
       run: dotnet pack HumanReadableCalculationSteps/HumanReadableCalculationSteps.csproj --configuration Release --no-build --output ./artifacts
 
     - name: Publish to NuGet
+      if: env.SKIP_RELEASE != 'true'
       run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Publish to GitHub Packages
+      if: env.SKIP_RELEASE != 'true'
       run: |
         dotnet nuget add source --username AppifySheets --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/AppifySheets/index.json"
         dotnet nuget push ./artifacts/*.nupkg --source "github" --skip-duplicate
 
     - name: Create GitHub Release
-      if: startsWith(github.ref, 'refs/tags/') && github.event_name != 'release'
+      if: env.SKIP_RELEASE != 'true' && startsWith(github.ref, 'refs/tags/') && github.event_name != 'release'
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
The current GitHub Actions workflow runs on **any** tag push, regardless of which branch the tag is on. This caused the v1.2.0 release to trigger from a `release/v1.2.0` branch before the code was merged to `main`, potentially publishing code that hasn't been properly reviewed or integrated.

## Solution
This PR adds a safety check to ensure the CI/CD pipeline only publishes releases when:
1. The tag exists on the `main` branch (using `git merge-base --is-ancestor`)
2. The code has been properly merged and reviewed

## Changes
- ✅ **Added branch validation**: Check if tag commit is reachable from `main` branch
- ✅ **Skip logic**: Gracefully skip release process if tag is not on `main`
- ✅ **Clear messaging**: Log why release was skipped
- ✅ **Conditional steps**: All build/test/publish steps only run for valid main branch tags

## How it works
```yaml
# Before publishing, check if tag is on main branch
- name: Check if tag is on main branch
  if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
  run:  < /dev/null | 
    if \! git merge-base --is-ancestor $TAG_NAME origin/main; then
      echo "❌ Tag $TAG_NAME is not on main branch. Skipping release."
      echo "SKIP_RELEASE=true" >> $GITHUB_ENV
    fi

# All subsequent steps check SKIP_RELEASE environment variable
- name: Setup .NET
  if: env.SKIP_RELEASE \!= 'true'
```

## Benefits
- 🛡️ **Safety**: Prevents accidental releases from feature/release branches
- 🔒 **Quality**: Ensures only reviewed, merged code gets published
- 📦 **Reliability**: No more publishing packages before code reaches main
- ✅ **Backwards Compatible**: Doesn't break existing release workflows

## Testing
- Workflow will still trigger on tag pushes (for logging/visibility)
- Will gracefully skip if tag is not on main branch
- Will continue normally for tags properly created on main branch

## Future Workflow
With this change, the recommended release process becomes:
1. Feature branch → PR → Review → Merge to `main`
2. Create tag directly on `main` branch: `git tag v1.x.x && git push origin v1.x.x`
3. CI/CD runs and publishes (because tag is on main)

No more need for separate release branches\! 🎉

🤖 Generated with [Claude Code](https://claude.ai/code)