### PR TITLE
Fix NuGet package icon path configuration

### DIFF
--- a/HumanReadableCalculationSteps/HumanReadableCalculationSteps.csproj
+++ b/HumanReadableCalculationSteps/HumanReadableCalculationSteps.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>.\assets\icon.png</PackageIcon>
+    <PackageIcon>assets/icon.png</PackageIcon>
     
     <!-- Versioning -->
     <Version>1.3.2</Version>
@@ -33,7 +33,7 @@
   <ItemGroup>
     <None Include="../LICENSE" Pack="true" PackagePath="/" />
     <None Include="../README.md" Pack="true" PackagePath="/" />
-    <None Include="../assets/icon.png" Pack="true" PackagePath="\" />
+    <None Include="../assets/icon.png" Pack="true" PackagePath="assets/" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions build failure for NuGet packaging by correcting the icon path configuration.

## Problem
The NuGet packaging was failing with error: "The icon file './assets/icon.png' does not exist in the package."

## Solution
- Changed `PackageIcon` from `.\assets\icon.png` to `assets/icon.png`
- Updated `PackagePath` to `assets/` to properly include the icon in the assets folder within the package

## Impact
- Resolves GitHub Actions workflow failures
- Enables successful NuGet package publishing
- Ensures the package icon is properly included in published packages under the correct path

🤖 Generated with [Claude Code](https://claude.ai/code)