### PR TITLE
Fix NuGet package icon to be placed in package root

### DIFF
--- a/HumanReadableCalculationSteps/HumanReadableCalculationSteps.csproj
+++ b/HumanReadableCalculationSteps/HumanReadableCalculationSteps.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>assets/icon.png</PackageIcon>
+    <PackageIcon>icon.png</PackageIcon>
     
     <!-- Versioning -->
     <Version>1.3.2</Version>
@@ -33,7 +33,7 @@
   <ItemGroup>
     <None Include="../LICENSE" Pack="true" PackagePath="/" />
     <None Include="../README.md" Pack="true" PackagePath="/" />
-    <None Include="../assets/icon.png" Pack="true" PackagePath="assets/" />
+    <None Include="../assets/icon.png" Pack="true" PackagePath="icon.png" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Fixes the NuGet package icon visibility issue by ensuring the icon is placed in the package root.

## Problem
The icon was not visible in NuGet package listings because it was placed in an `assets/` folder within the package instead of the package root.

## Solution
- Changed `PackageIcon` to reference `icon.png` (file in package root)
- Updated `PackagePath` to `icon.png` to place the icon directly in the package root
- The physical file remains in `assets/icon.png` in the repository

## Technical Details
- `Include="../assets/icon.png"` - Source file location in repo
- `PackagePath="icon.png"` - Destination in package (root level)
- `PackageIcon>icon.png</PackageIcon>` - Reference for NuGet to find icon

## Impact
- Icon will now be visible in NuGet.org package listings
- Proper package icon display for better package discoverability

🤖 Generated with [Claude Code](https://claude.ai/code)