### PR TITLE
Fix showcase numeric result to match FinalCalculationSteps formatting

### DIFF
--- a/HumanReadableCalculationSteps.Examples/Program.cs
+++ b/HumanReadableCalculationSteps.Examples/Program.cs
@@ -137,7 +137,7 @@ foreach (var (title, code, build) in examples)
 {
     var value = build();
     var steps = value.FinalCalculationSteps;
-    var resultValue = value.Value.ToString(CultureInfo.InvariantCulture);
+    var resultValue = FormatDisplayValue(value.Value);
 
     output.AppendLine($"## {title}");
     output.AppendLine();
@@ -168,3 +168,13 @@ Console.WriteLine($"Wrote {examples.Length} examples to {Path.GetFullPath(target
 // needing to download the artifact for quick eyeballing.
 Console.WriteLine();
 Console.WriteLine(output.ToString());
+
+// Format a value to match what FinalCalculationSteps renders: round to 2 decimal
+// places, strip trailing zeros, add thousand separators. Without this, raw
+// decimal.ToString() leaks the decimal type's accumulated scale (e.g. "1350.0",
+// "100.30", "30.0") which visually contradicts the FinalCalculationSteps line
+// directly below in the showcase output and makes reviewers wonder which
+// representation is the "real" one. The library's internal CleanDecimalFormatting
+// helper does the same job for FinalCalculationSteps; we mirror its rules here.
+static string FormatDisplayValue(decimal value) =>
+    Math.Round(value, 2).ToString("#,##0.##", CultureInfo.InvariantCulture);


### PR DESCRIPTION
## Summary

- The CI calculation showcase prints each example with two views of the result: a **Numeric result** line (raw `decimal.ToString()`) and the **FinalCalculationSteps** trace (library-formatted). These disagreed visually whenever decimal arithmetic accumulated scale.
- The trailing zeros aren't a library bug — they're how `decimal` preserves scale across arithmetic (e.g. \`15m * 100m * 0.1m\` yields \`150.0m\`). But surfacing that quirk in the showcase makes a reviewer wonder which view is the \"real\" one, and undermines the showcase's whole point of demonstrating the library's clean output.
- Fix: format the numeric result with \`Math.Round(value, 2).ToString(\"#,##0.##\", InvariantCulture)\` so both lines in every example agree.

### Before vs After

| Example | Before (Numeric result) | After | FinalCalculationSteps |
|---|---|---|---|
| Multi-level chain | \`1350.0\` | \`1,350\` | \`1,350\` |
| Wrapped intermediate | \`100.30\` | \`100.3\` | \`100.3\` |
| Sum + arithmetic | \`30.0\` | \`30\` | \`30\` |
| Long multiline | \`675.0\` | \`675\` | \`675\` |
| Unicode (Georgian) | \`100.30\` | \`100.3\` | \`100.3\` |
| Division rounding | \`33.3333333333333333333333333\` | \`33.33\` | \`33.33\` |

## Test plan

- [ ] CI \`Build & test\` job still passes (no library changes; this is a one-line Examples-project edit).
- [ ] Workflow's \"Render showcase into job summary\" step displays matching values for the Numeric result and the value rendered inside FinalCalculationSteps for every example.
- [ ] Downloaded \`calculation-showcase-\${run_id}\` artifact shows the same.

*Collaboration by Claude*